### PR TITLE
Allow JAVA_OPTS to be Specified

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -18,9 +18,10 @@ COPY --from=build /home/app/server/target/server-*.jar /opt/flare/flare.jar
 RUN chown -R 10001:10001 /opt/flare
 ARG VERSION=0.0.0
 ENV APP_VERSION=${VERSION}
+ENV JAVA_OPTS=""
 
 USER 10001
-ENTRYPOINT ["java","-jar","flare.jar"]
+ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} -jar flare.jar"]
 EXPOSE 8080
 
 ARG GIT_REF=""


### PR DESCRIPTION
Allows to specify java options via environment variables.

For example using a custom trust store can be achieved by specifying the following options:
`-Djavax.net.ssl.trustStore=<path-to-trust-store> -Djavax.net.ssl.trustStorePassword=<trust-store-pw>`